### PR TITLE
add EnvironmentalScan submod

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "EnvironmentalScan"]
+	path = EnvironmentalScan
+	url = https://github.com/DLFMetadataAssessment/EnvironmentalScan.git


### PR DESCRIPTION
Notes on the deploy process:

```git clone https://github.com/DLFMetadataAssessment/Sandbox.git 
cd Sandbox```

Added Metadata Clearinghouse as a submodule with 
```git submodule add https://github.com/DLFMetadataAssessment/MetadataSpecsClearinghouse```

Added Environmental Scan as a submodule with 
```git submodule add https://github.com/DLFMetadataAssessment/EnvironmentalScan.git```

Connect to Heroku git after setting up Heroku cli
```heroku git:remote -a dlfaigmwg```

Deploy to Heroku - CAUTION: anything on the master branch will deploy automatically
```git push heroku master```

```git submodule add https://github.com/DLFMetadataAssessment/EnvironmentalScan.git```

##Note on branches
* Only the master branch will be deployed to Heroku
* Use another branch when pushing to GitHub, but make sure it's the same as your master branch that gets pushed to Heroku

```git add .
git commit -m 'add EnvironmentalScan submod'

git push heroku master
```

Access the submodule at https://dlfaigfork.herokuapp.com/EnvironmentalScan

```git checkout issue#branch

git push origin issue#branch
```

Note: I didn't want to destroy our current Heroku deploy, so I tested it on my fork and deployed to a separate Heroku app. The main issue with this method is that Heroku automatically deploys the master branch, so it could be a bit of a mess to try to deploy this to our Heroku app before it's merged into the master branch.

Parent repo at: https://dlfaigfork.herokuapp.com/
Child repo at: https://dlfaigfork.herokuapp.com/EnvironmentalScan
Environmental scan generating _site: https://dlfaigfork.herokuapp.com/EnvironmentalScan/entries/34tools.html