### PR TITLE
Issue#71

### DIFF
--- a/entries/contributors.md
+++ b/entries/contributors.md
@@ -8,7 +8,7 @@ title: contributors
 <h2>Contributors</h2>
 <h3>2017</h3>
 
-This list of contributors was created based on the lists of people who attendee either the regular Metadata Working Group meeting or any of the subgroup meetings.
+This list of contributors was created based on the lists of people who attended either the regular Metadata Working Group meeting or any of the subgroup meetings.
 
 - - --  Laura Akerman
 - - --  Shaun Akhtar

--- a/index.md
+++ b/index.md
@@ -9,10 +9,10 @@ sectionclass: h1
 
    <p>This is the website for the Digital Library Federation (DLF) Assessment Interest Group (AIG) Metadata Working Group, also known as the DLF Metadata Assessment Working Group.</p>    
    <p>This site contains information about a number of projects this group has undertaken including:</p>
-- - --<a href="https://dlfmetadataassessment.github.io/EnvironmentalScan">the Environmental Scan undertaken during 2016</a>
+- - --<a href="https://dlfmetadataassessment.github.io/EnvironmentalScan">The Environmental Scan undertaken during 2016</a>
 - - --<a href="https://dlfmetadataassessment.github.io/Framework">A level framework for assessing descriptive metadata in digital collections</a>
 - - --<a href="https://dlfmetadataassessment.github.io/Tools">The ongoing work to build a repository of metadata assessment tools</a>
-- - --<a href="https://dlfmetadataassessment.github.io/MetadataSpecsClearinghouse">A colleciton of application profiles, mappsings and practices</a>
+- - --<a href="https://dlfmetadataassessment.github.io/MetadataSpecsClearinghouse">A collection of application profiles, mappings and practices</a>
 <br/>
 <p>You can also:</p>
 - - --<a href="/entries/about.html">Find out more about this group</a>


### PR DESCRIPTION
Fixes a couple of typos. It does not change text on the "Tools" page, where the original note was:

> In a separate section, "Tools", I'm unsure, but think there may be a missing paragraph break after the list, before `A working lunch session [...]`

To the best of my knowledge, that content is in the Tools repository? If that text should be tweaked, happy to submit a pull request there.