### PR TITLE
Relative links in previous update were relative to main site and not …

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -11,15 +11,15 @@
 		  </span>
 		</label>
 		<div>
-			<a href="/"><img class="header-logo" src="/img/dlf-aig.png"/></a>
+			<a href="/Sandbox"><img class="header-logo" src="/img/dlf-aig.png"/></a>
 		</div>
 		<div class="trigger">
-			<a class="page-link" href="/about">About</a>
-			<a class="page-link" href="/Projects">Projects</a>
-			<a class="page-link" href="/take-part">Participate</a>
-			<a class="page-link" href="/collaborations">Collaborations</a>
-			<a class="page-link" href="/contributors">Contributors</a>
-			<a class="page-link" href="/skillbuilding">Skillbuilding</a>
+			<a class="page-link" href="/Sandbox/about">About</a>
+			<a class="page-link" href="/Sandbox/Projects">Projects</a>
+			<a class="page-link" href="/Sandbox/take-part">Participate</a>
+			<a class="page-link" href="/Sandbox/collaborations">Collaborations</a>
+			<a class="page-link" href="/Sandbox/contributors">Contributors</a>
+			<a class="page-link" href="/Sandbox/skillbuilding">Skillbuilding</a>
 		</div>
 	  </nav>
   </div>

--- a/entries/projects.markdown
+++ b/entries/projects.markdown
@@ -6,8 +6,8 @@ permalink: Projects
 
 The DLF Assessment Interest Group (AIG) Metadata Working Group (MWG) has undertaken a number of projects since it was formed in 2015. Below you will find more information about the projects that the MWG has undertaken or is currently working on.
 
-* [Environmental Scan](/EnvironmentalScan)
-* [Metadata Assessment Framework](/Framework)
-* [Tools for Metadata Assessment](/Tools)
+* [Environmental Scan](/Sandbox/EnvironmentalScan)
+* [Metadata Assessment Framework](/Sandbox/Framework)
+* [Tools for Metadata Assessment](/Sandbox/Tools)
 * [Metadata Application Profile Clearinghouse](https://dlfmetadataassessment.github.io/MetadataSpecsClearinghouse)
-* [Metadata Benchmarks](/MetadataBenchmarks)
+* [Metadata Benchmarks](/Sandbox/MetadataBenchmarks)

--- a/index.md
+++ b/index.md
@@ -10,14 +10,14 @@ This is the website for the Digital Library Federation (DLF) Assessment Interest
 
 This site contains information about several projects that this group has undertaken, including:
    
-* [An <b>environmental scan</b> of metadata assessment and metadata quality literature, tools, presentations, and organizations (originally undertaken in 2016, currently under review)](/EnvironmentalScan).
-* [A <b>framework</b> for assessing descriptive metadata in digital collections (undertaken in 2017)](/Framework).
+* [An <b>environmental scan</b> of metadata assessment and metadata quality literature, tools, presentations, and organizations (originally undertaken in 2016, currently under review)](/Sandbox/EnvironmentalScan).
+* [A <b>framework</b> for assessing descriptive metadata in digital collections (undertaken in 2017)](/Sandbox/Framework).
 * [A <b>repository</b> for metadata assessment tools (Ongoing/Current)](/Tools).
 * [A <b>collection</b> of metadata application profiles, mappings, and practices (Ongoing/Current)](https://dlfmetadataassessment.github.io/MetadataSpecsClearinghouse).
-* [A <b>survey</b> of metadata assessment and metadata quality practices among various libraries, archives, and museums (Ongoing/Current)](/MetadataBenchmarks).
+* [A <b>survey</b> of metadata assessment and metadata quality practices among various libraries, archives, and museums (Ongoing/Current)](/Sandbox/MetadataBenchmarks).
 
 You can also learn more about:
-* [This group](/about).
-* [How to take part](/take-part).
-* [The collaborations we've taken part in](/collaborations).
-* [The people who have made this site possible](/contributors).
+* [This group](/Sandbox/about).
+* [How to take part](/Sandbox/take-part).
+* [The collaborations we've taken part in](/Sandbox/collaborations).
+* [The people who have made this site possible](/Sandbox/contributors).

--- a/index.md
+++ b/index.md
@@ -12,7 +12,7 @@ This site contains information about several projects that this group has undert
    
 * [An <b>environmental scan</b> of metadata assessment and metadata quality literature, tools, presentations, and organizations (originally undertaken in 2016, currently under review)](/Sandbox/EnvironmentalScan).
 * [A <b>framework</b> for assessing descriptive metadata in digital collections (undertaken in 2017)](/Sandbox/Framework).
-* [A <b>repository</b> for metadata assessment tools (Ongoing/Current)](/Tools).
+* [A <b>repository</b> for metadata assessment tools (Ongoing/Current)](/Sandbox/Tools).
 * [A <b>collection</b> of metadata application profiles, mappings, and practices (Ongoing/Current)](https://dlfmetadataassessment.github.io/MetadataSpecsClearinghouse).
 * [A <b>survey</b> of metadata assessment and metadata quality practices among various libraries, archives, and museums (Ongoing/Current)](/Sandbox/MetadataBenchmarks).
 


### PR DESCRIPTION
…Sandbox. So they don't work as intended as they currently are (though they're right for the production/main site).

Before transferring the production site these links will need to be updated.