### PR TITLE
Issue#127

### DIFF
--- a/index.md
+++ b/index.md
@@ -1,23 +1,16 @@
 ---
 layout: page
-title: home
+title: Home
 ---
 
 {::options parse_block_html="true" /}
 # DLF AIG MWG Metadata Assessment Toolkit
 
-This is the website for the Digital Library Federation (DLF) Assessment Interest Group (AIG) Metadata Working Group, also known as the DLF Metadata Assessment Working Group.
+This is the website for the Digital Library Federation (DLF) Assessment Interest Group (AIG) Metadata Working Group, also known as the DLF AIG Metadata Assessment Working Group.
 
-This site contains information about a number of projects this group has undertaken including:
-   
-* [The Environmental Scan undertaken during 2016](https://dlfmetadataassessment.github.io/EnvironmentalScan)
-* [A level framework for assessing descriptive metadata in digital collections](https://dlfmetadataassessment.github.io/Framework)
-* [The ongoing work to build a repository of metadata assessment tools](https://dlfmetadataassessment.github.io/Tools)
-* [A collection of application profiles, mappings and practices](https://dlfmetadataassessment.github.io/MetadataSpecsClearinghouse)
-
-
-You can also:
-* [Find out more about this group](/entries/about.html)
-* [Find out more about how to take part](/entries/take-part.html)
-* [Find out about the collaborations we've taken part in](/entries/collaborations.html)
-* [Find out the people who have made this site possible](/entries/contributors.html)
+Here, you can learn more about:
+* [This group](/Sandbox/about).
+* [The projects that this group has undertaken or completed](/Sandbox/Projects).
+* [How to take part](/Sandbox/take-part).
+* [The collaborations we've taken part in](/Sandbox/collaborations).
+* [The people who have made this working group a success](/Sandbox/contributors).

--- a/projects.markdown
+++ b/projects.markdown
@@ -13,5 +13,5 @@ Below you will find more information about the projects that the DLF AIG Metadat
 * [A <b>repository</b> for metadata assessment tools (Ongoing/Current)](/Sandbox/Tools).
 * [A <b>collection</b> of metadata application profiles, mappings, and practices (Ongoing/Current)](https://dlfmetadataassessment.github.io/MetadataSpecsClearinghouse).
 * [A <b>survey</b> of metadata assessment and metadata quality practices among various libraries, archives, and museums (Ongoing/Current)](/Sandbox/MetadataBenchmarks).
-* [A Metadata Analysis Workshop designed to introduce library, archive, and museum metadata practitioners and technologists to the basic skills and knowledge needed to assess metadata quality using data analysis tools (originally undertaken in 2017 and updated in 2018](/Sandbox/MetadataWorkshop).
+* [A <b>Metadata Analysis Workshop</b> designed to introduce library, archive, and museum metadata practitioners and technologists to the basic skills and knowledge needed to assess metadata quality using data analysis tools (originally undertaken in 2017 and updated in 2018](/Sandbox/MetadataWorkshop).
 

--- a/projects.markdown
+++ b/projects.markdown
@@ -1,18 +1,17 @@
 ---
-sectionid: projects
-sectionclass: h1
-is-parent: yes
 title: projects
-number: 20
 layout: page
+permalink: Projects
 ---
 
-<h1>Projects</h1>
+The DLF Assessment Interest Group (AIG) Metadata Working Group (MWG) has undertaken a number of projects since it was formed in 2015. 
 
-Learn more about the projects the Metadata Working Group is doing!
+Below you will find more information about the projects that the DLF AIG Metadata Assessment Working Group has completed or is currently working on, including:
 
-* [Environmental Scan](http://dlfmetadataassessment.github.io/EnvironmentalScan/)
-* [Metadata Assessment Framework](http://dlfmetadataassessment.github.io/Framework)
-* [Tools for Metadata Assessment](https://dlfmetadataassessment.github.io/Tools)
-* [Metadata Application Profile Clearinghouse](https://dlfmetadataassessment.github.io/MetadataSpecsClearinghouse)
-* [Metadata Benchmarks]()
+* [An <b>environmental scan</b> of metadata assessment and metadata quality literature, tools, presentations, and organizations (originally undertaken in 2016, currently under review)](/Sandbox/EnvironmentalScan).
+* [A <b>framework</b> for assessing descriptive metadata in digital collections (undertaken in 2017)](/Sandbox/Framework).
+* [A <b>repository</b> for metadata assessment tools (Ongoing/Current)](/Sandbox/Tools).
+* [A <b>collection</b> of metadata application profiles, mappings, and practices (Ongoing/Current)](https://dlfmetadataassessment.github.io/MetadataSpecsClearinghouse).
+* [A <b>survey</b> of metadata assessment and metadata quality practices among various libraries, archives, and museums (Ongoing/Current)](/Sandbox/MetadataBenchmarks).
+* [A Metadata Analysis Workshop designed to introduce library, archive, and museum metadata practitioners and technologists to the basic skills and knowledge needed to assess metadata quality using data analysis tools (originally undertaken in 2017 and updated in 2018](/Sandbox/MetadataWorkshop).
+

--- a/projects.markdown
+++ b/projects.markdown
@@ -1,8 +1,13 @@
 ---
+sectionid: projects
+sectionclass: h1
+is-parent: yes
 title: projects
+number: 20
 layout: page
 permalink: Projects
 ---
+<h1>Projects</h1>
 
 The DLF Assessment Interest Group (AIG) Metadata Working Group (MWG) has undertaken a number of projects since it was formed in 2015. 
 


### PR DESCRIPTION
Should fix issue #127  and #126. 

Also changed the language on the home page--prior text implied that the contributors only contributed to the website itself.

Also, the fifth sentence on the Metadata Analysis workshop entry appears to have present tense language (e.g. "The updated curriculum included an introduction to the [Metadata Assessment Framework](/Framework) developed by the Metadata Working Group and **will close by** helping participants strategize ways to bring these tools back into their daily workflows and continue to train others they work with to do the same"). Should this bolded language be changed to past tense?

Finally, @kateefly , could you look this over when you get a free second to see why the request can't be automatically merged? 



