### PR TITLE
Add quotes to Louisville spec so it renders properly

### DIFF
--- a/_metadata_specs/louisville.md
+++ b/_metadata_specs/louisville.md
@@ -1,5 +1,5 @@
 ---
-title: CONTENTdm Cookbook: Recipes for metadata entry for UofL Digital Initiatives
+title: "CONTENTdm Cookbook: Recipes for metadata entry for UofL Digital Initiatives"
 year: 2015
 version: 1.0
 kind: PDF


### PR DESCRIPTION
Should fix issue#251. Adds quotes to Louisville spec so Title that had a colon will render properly.