### PR TITLE
Redirect /MetadataSpecsClearinghouse/* using jekyll-redirect-from plugin

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,4 +2,6 @@ source "https://rubygems.org"
 
 gem "github-pages", group: :jekyll_plugins
 
+gem "jekyll-redirect-from", "~> 0.16.0"
+
 gem "webrick", "~> 1.7"

--- a/_config.yml
+++ b/_config.yml
@@ -39,3 +39,6 @@ exclude:
 
 sass:
   style: compressed
+
+plugins:
+  - jekyll-redirect-from

--- a/projects/metadata-application-profiles/index.md
+++ b/projects/metadata-application-profiles/index.md
@@ -1,5 +1,26 @@
 ---
 title: Metadata Application Profiles
+redirect_from:
+  - /MetadataSpecsClearinghouse/
+  - /MetadataSpecsClearinghouse/about/
+  - /MetadataSpecsClearinghouse/carnegie-hall/
+  - /MetadataSpecsClearinghouse/dlsd/
+  - /MetadataSpecsClearinghouse/dpla/
+  - /MetadataSpecsClearinghouse/esdn/
+  - /MetadataSpecsClearinghouse/fhsu/
+  - /MetadataSpecsClearinghouse/idhh/
+  - /MetadataSpecsClearinghouse/louisville/
+  - /MetadataSpecsClearinghouse/msu/
+  - /MetadataSpecsClearinghouse/mwdl/
+  - /MetadataSpecsClearinghouse/nyarc/
+  - /MetadataSpecsClearinghouse/ocul/
+  - /MetadataSpecsClearinghouse/odn/
+  - /MetadataSpecsClearinghouse/padigital/
+  - /MetadataSpecsClearinghouse/rice-university/
+  - /MetadataSpecsClearinghouse/scdl/
+  - /MetadataSpecsClearinghouse/uic/
+  - /MetadataSpecsClearinghouse/university-of-houston/
+  - /MetadataSpecsClearinghouse/usu/
 bottom-of-page:
   - js-search.min.js
   - maps-search.js


### PR DESCRIPTION
I believe this will work on production but not on sandbox and not while a baseurl is set. Since what needs to redirect is https://dlfmetadataassessment.github.io/MetadataSpecsClearinghouse/ and this URL does not have a sandbox subdirectory, a match for the redirect to happen will not occur on sandbox (or locally with `baseurl: /Sandbox`). You can still test this locally by going to http://localhost:4000/Sandbox/MetadataSpecsClearinghouse/ and confirming that it redirects. On production, when `baseurl: /Sandbox` is gone, everything should redirect 100% as expected.