### PR TITLE
Fixes #303

### DIFF
--- a/.github/ISSUE_TEMPLATE/metadata-resource-submission.md
+++ b/.github/ISSUE_TEMPLATE/metadata-resource-submission.md
@@ -13,7 +13,7 @@ assignees: ''
 
 This form will allow you to submit your institution's application profiles, mappings, crosswalks and metadata code as digital files to the Clearinghouse project[1]. The MAP Clearinghouse is a project of the Digital Library Federation (DLF) Assessment Interest Group (AIG) Metadata Assessment Working Group[2]. The Metadata Assessment Working Group aims to build guidelines, best practices, tools and workflows around the evaluation and assessment of (mostly, descriptive) metadata used by and for digital libraries and repositories.
 
-[1] https://dlfmetadataassessment.github.io/MetadataSpecsClearinghouse/
+[1] https://dlfmetadataassessment.github.io/projects/metadata-application-profiles/
 [2] https://dlfmetadataassessment.github.io/
 
 The following information will be used to describe your document(s) when on the Clearinghouse website. Please be aware that if you do not complete the mandatory portions of this submission form, we may not be able to include your document(s) in the Clearinghouse.
@@ -67,4 +67,4 @@ Within each section, replace "Type your answer here" with the requested informat
 
 *Please attach your file(s) using the drag and drop or selection method described at the end of this box.*
 
-*If your content exceeds 10 MB, or if you have any questions or feedback, please contact the Metadata Assessment Working Group at [email address].*
+*If your content exceeds 10 MB, or if you have any questions or feedback, please contact the Metadata Assessment Working Group through our [Google Group](https://groups.google.com/g/dlf-aig-metadata-assessment-working-group).*

--- a/projects/metadata-application-profiles/index.md
+++ b/projects/metadata-application-profiles/index.md
@@ -31,6 +31,8 @@ Scope
 
 The Clearinghouse is intended to be an extensible collection/repository of metadata application profiles, mappings, and related specifications that aid or guide descriptive metadata conventions in digital repository collections. The Clearinghouse intends to make these example documents freely-available as downloadable files, as web pages are subject to change and web links are subject to “reference rot.”
 
+You can submit a new resource to the Clearinghouse by [submitting a new issue in GitHub](https://github.com/DLFMetadataAssessment/Sandbox/issues/new?assignees=&labels=MAP+Clearinghouse+submission&projects=&template=metadata-resource-submission.md&title=New+MAP+Clearinghouse+resource).
+
 Mission
 -------
 


### PR DESCRIPTION
This PR updates the Sandbox with the minor updates to the issue template made on the main site.

It also adds a link to open a new issue (using the template) to the Metadata Application Profiles page. Note that instead of opening a new issue in the main repository like the link on the main site is currently set up to do, this link opens a new issue in the Sandbox repository. We've decided to open new MAP resource issues in the Sandbox going forward, so we're okay with this link being coped over to the main site and overwriting what's there.