### PR TITLE
update current efforts on about page

### DIFF
--- a/about/index.md
+++ b/about/index.md
@@ -18,13 +18,13 @@ We hope that this resource offers a way for fellow metadata professionals to per
 Current efforts
 ------------
 
-The 2022 DLF Metadata Assessment Working Group’s efforts focused on:
+The 2023 DLF Metadata Assessment Working Group’s efforts focused on:
 
 *   [Publicizing information about the group and about metadata quality through blog posts and social media](https://www.diglib.org/category/assessment/)
-*   [Evaluating next steps for benchmarking based on survey data](/Sandbox/projects/benchmarks)
-*   Compiling a list of resources related to skill-building for metadata quality activities
-*   [Standardizing and maintaining a metadata analysis tools repository](/Sandbox/projects/tools)
+*   [Evaluating next steps for benchmarking based on survey data]({{ "projects/benchmarks" | relative_url }})
+*   [Standardizing and maintaining a metadata analysis tools repository]({{ "/projects/tools/" | relative_url }})
 *   Updating the DLF Metadata Assessment Working Group’s website
+*   Reviewing and updating a glossary of digital library terms
 
 Prior Efforts
 -------------


### PR DESCRIPTION
Fixes #311 

- converted URLs to relative URLs
- removed entry referencing skill-building resources subgroup
- added entry referencing digital library glossary subgroup